### PR TITLE
#40: Make fragility plotting methods compatible with DFR3 naming changes

### DIFF
--- a/pyincore_viz/plotutil.py
+++ b/pyincore_viz/plotutil.py
@@ -60,9 +60,8 @@ class PlotUtil:
         x = numpy.linspace(start, end, sample_size)
         y = []
         for i in x:
-            y.append(curve.calculate_limit_state_probability(hazard_values={demand_type_name: i},
-                                                             curve_parameters=curve_parameters,
-                                                             **custom_curve_parameters))  # kwargs
+            y.append(curve.solve_curve_expression(hazard_values={demand_type_name: i},
+                                                  curve_parameters=curve_parameters, **custom_curve_parameters))
         y = numpy.asarray(y)
         return x, y
 
@@ -89,10 +88,10 @@ class PlotUtil:
         x = y = numpy.arange(start, end, sample_size)
 
         def _f(curve, x, y):
-            return curve.calculate_limit_state_probability(hazard_values={demand_type_names[0]: x,
-                                                                          demand_type_names[1]: y},
-                                                           curve_parameters=curve_parameters,
-                                                           **custom_curve_parameters)  # kwargs
+            return curve.solve_curve_expression(hazard_values={demand_type_names[0]: x,
+                                                demand_type_names[1]: y},
+                                                curve_parameters=curve_parameters,
+                                                **custom_curve_parameters)  # kwargs
 
         X, Y = numpy.meshgrid(x, y)
         z = numpy.array([_f(curve, x, y) for x, y in zip(numpy.ravel(X), numpy.ravel(Y))])
@@ -227,10 +226,10 @@ class PlotUtil:
             if limit_state == curve.return_type["description"]:
                 matched = True
                 x, y, z = PlotUtil.get_x_y_z(curve,
-                                                        demand_type_names[:2],
-                                                        fragility_set.curve_parameters,
-                                                        custom_curve_parameters,
-                                                        **kwargs)
+                                             demand_type_names[:2],
+                                             fragility_set.curve_parameters,
+                                             custom_curve_parameters,
+                                             **kwargs)
                 ax = plt.axes(projection='3d')
                 ax.plot_surface(x, y, z, rstride=1, cstride=1, cmap='viridis', edgecolor='none')
                 ax.set_xlabel(fragility_set.demand_types[0] + " (" + fragility_set.demand_units[0] + ")")


### PR DESCRIPTION
Closes #40 

To test:
change pyincore version in requirements.txt to `1.3.0.rc.1`
Install rc version: `conda/mamba install -c in-core/label/rc pyincore`
Run pytest and verify that the DFR3 images created on your local are good. 8 files should be created called - standard.png, conditional.png etc.
