### PR TITLE
Make pyincore viz build with legacy naming for pypi publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unrelease]
+## [Unreleased]
 ### Changed
 - Made pyincore-viz build with legacy naming for pypi publish. [#57](https://github.com/IN-CORE/pyincore-viz/issues/57)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unrelease]
+### Changed
+- Made pyincore-viz build with legacy naming for pypi publish. [#57](https://github.com/IN-CORE/pyincore-viz/issues/57)
+
 ## [1.5.1] - 2022-04-12
 ### Fixed
 - Boolean comparison in adding dislocation dataframe. [#52](https://github.com/IN-CORE/pyincore-viz/issues/52)

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,8 @@
 # and is available at https://www.mozilla.org/en-US/MPL/2.0/
 
 from setuptools import setup, find_packages
+import pkg_resources
+pkg_resources.extern.packaging.version.Version = pkg_resources.SetuptoolsLegacyVersion
 
 setup(
     name='pyincore-viz',


### PR DESCRIPTION
This will allow to build pyincore-viz package using the legacy naming 