### PR TITLE
run apt update

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get install -y python3-gdal
+          apt-get update
+          apt-get install -y python3-gdal
           python -m pip install --upgrade pip setuptools wheel
 
       - name: Install dependencies

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y python3-gdal
+          sudo apt-get update
+          sudo apt-get install -y python3-gdal
           python -m pip install --upgrade pip setuptools wheel
 
       - name: Install dependencies


### PR DESCRIPTION
before installing run `apt update` this will make sure we have latest list of packages. This is important in case a package is removed due to a critical security problem.