### PR TITLE
fxied rasterio crs error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- CRS error caused by rasterio. [#86](https://github.com/IN-CORE/pyincore-viz/issues/86)
+
 ## [1.8.0] - 2022-09-14
 
 ### Added

--- a/pyincore_viz/geoutil.py
+++ b/pyincore_viz/geoutil.py
@@ -92,8 +92,13 @@ class GeoUtil:
             eq_crs = r.crs
 
         ax = gdf.plot(figsize=(10, 10), column=column, categorical=False, legend=True)
-        ctx.add_basemap(ax, crs=eq_crs, source=ctx.providers.OpenStreetMap.Mapnik,)
-        ctx.add_basemap(ax, crs=eq_crs, source=file_path, alpha=0.5)
+        # TODO there is a problem in crs in following lines.
+        #  It should be better to add crs to ctx.add_basemap like following
+        #  ctx.add_basemap(ax, crs=eq_crs, source=ctx.providers.OpenStreetMap.Mapnik)
+        #  However there is an error in rasterio so the crs part has been omitted.
+        #  Since incore only use WGS84 for whole dataset, this should be safe
+        ctx.add_basemap(ax, source=ctx.providers.OpenStreetMap.Mapnik)
+        ctx.add_basemap(ax, source=file_path, alpha=0.5)
 
     @staticmethod
     def join_datasets(geodataset, dataset):


### PR DESCRIPTION
There is a crs error in rasterio and pyincore-viz has related to that when using the raster. Those are disabled and it should be okay since incore only uses single projection that is WGS 84. 