### PR TITLE
deprecated inventory_to_geodataframe from plotutil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - CRS error caused by rasterio. [#86](https://github.com/IN-CORE/pyincore-viz/issues/86)
 
+## [Unreleased]
+
+### Changed
+- Deprecated inventory_to_geodataframe method from plotutil. [#89](https://github.com/IN-CORE/pyincore-viz/issues/89)
+ 
 ## [1.8.0] - 2022-09-14
 
 ### Added

--- a/pyincore_viz/plotutil.py
+++ b/pyincore_viz/plotutil.py
@@ -232,6 +232,8 @@ class PlotUtil:
         return plt
 
     @staticmethod
+    @deprecated(version="1.9.0",
+                reason="It is not being used anymore. Check pyincore's Dataset.get_dataframe_from_shapefile")
     def inventory_to_geodataframe(inventory_dataset):
         """Convert inventory_dataset to GeoDataFrame.
 


### PR DESCRIPTION
Since the method is deprecated, not deleted, if there is any user who uses the method still should be okay I believe