### PR TITLE
Update ipyleaflet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Updated ipyleaflet to 0.17.2 [#117](https://github.com/IN-CORE/pyincore-viz/issues/117)
 ## [1.8.1] - 2022-11-16
 
 ### Changed

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - contextily>=1.0.0
   - deprecated
   - geopandas>=0.6.1
-  - ipyleaflet>=0.16.0
+  - ipyleaflet>=0.17.2
   - ipywidgets>=7.6.0
   - lxml>=4.6.3
   - matplotlib>=2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ branca>=0.3.0
 contextily>=1.0.0
 deprecated
 geopandas>=0.6.1
-ipyleaflet>=0.16.0
+ipyleaflet>=0.17.2
 ipywidgets>=7.6.0
 lxml>=4.6.3
 matplotlib>=2.1.0


### PR DESCRIPTION
ipyleaflet has been updated to latest version that is 0.17.2. You can test it by installing pyincore-viz 1.8.2rc1 from conda. You can use it in your local or installing it in incore-dev's incore-lab by
mamba install -c in-core/label/rc -y pyincore-viz=1.8.2rc1

Please ignore github action's documentation build error. I have created a separated issue to fix this.