### PR TITLE
Fixes #195 changed conda build to include package format argument for tar.bz2

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -67,7 +67,8 @@ jobs:
         run: |
           conda install conda-build
           mkdir dist
-          conda build --output-folder dist \
+          conda build --package-format=tar.bz2 \
+                      --output-folder dist \
                       --label ${{ env.LABEL }} \
                       recipes
         shell: micromamba-shell {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Changed
+- Conda build to include package format argument [#195](https://github.com/IN-CORE/pyincore-viz/issues/195)
+
 ### Fixed
 - Documentation container tagging error by github action [#181](https://github.com/IN-CORE/pyincore-viz/issues/181)
 - Pytest error caused by removed hazard dataset [#182](https://github.com/IN-CORE/pyincore-viz/issues/182)


### PR DESCRIPTION
Conda build from version 25.x defaults to .conda package, but we want the tar.bz2. I added a build argument to output tar.bz2. 

You can test this by doing the following:
1. creating a conda environment and activating it
2. Install conda-build by running conda install conda-build
3. mkdir dist in the parent folder
4. Run conda build --package-format=tar.bz2 --output-folder dist --label "RC" recipes

When the build finishes, the dist/ folder (or maybe one of the sub folders) should contain a tar.bz2 file.